### PR TITLE
make PyPi Repository work with Simple API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: groovy
 sudo: false
 jdk:
-  - openjdk7
+  - openjdk8

--- a/README.adoc
+++ b/README.adoc
@@ -57,7 +57,10 @@ By default the following two repository-patterns have been defined for the plugi
 - +pypi+
 - +https://github.com/${dep.group}/${dep.name}/archive/${dep.version}.tar.gz+
 
-The `pypi` repository uses PyPi's Simple API (`https://pypi.org/simple/${dep.name}/`) to query for the release of the specified version.
+The `pypi` repository pattern triggers special behavior. A REST call to `https://pypi.org/pypi/${dep.name}/json`
+is made and the URL for the `source` release for that version is retrieved from the response.
+
+The `pypiLegacy` repository uses PyPi's Simple API (`https://pypi.org/simple/${dep.name}/`) to query for the dependency.
 
 These can be overridden or extended using the `jython` extension. For instance:
 
@@ -68,6 +71,8 @@ jython {
   sourceRepositories = ['http://my.local.repo/${dep.name}/${dep.version}/${dep.name}-${dep.version}.tar.gz']
   // Add another repository to the existing ones
   repository 'pypi'
+  // Add self hosted PyPi repository
+  repository pypiLegacy('http://myselfhostedpypi.org/simple/${dep.name}/')
 }
 ----
 

--- a/README.adoc
+++ b/README.adoc
@@ -54,11 +54,10 @@ dependencies {
 == Configuration
 By default the following two repository-patterns have been defined for the plugin:
 
-- +pipy+
+- +pypi+
 - +https://github.com/${dep.group}/${dep.name}/archive/${dep.version}.tar.gz+
 
-The `pipy` repository pattern triggers special behavior. A REST call to `https://pypi.python.org/pypi/${dep.name}/json`
-is made and the URL for the `source` release for that version is retrieved from the response.
+The `pypi` repository uses PyPi's Simple API (`https://pypi.org/simple/${dep.name}/`) to query for the release of the specified version.
 
 These can be overridden or extended using the `jython` extension. For instance:
 
@@ -68,7 +67,7 @@ jython {
   // Replace all repositories with this one
   sourceRepositories = ['http://my.local.repo/${dep.name}/${dep.version}/${dep.name}-${dep.version}.tar.gz']
   // Add another repository to the existing ones
-  repository 'pipy'
+  repository 'pypi'
 }
 ----
 

--- a/src/main/groovy/com/hierynomus/gradle/plugins/jython/JythonExtension.groovy
+++ b/src/main/groovy/com/hierynomus/gradle/plugins/jython/JythonExtension.groovy
@@ -16,6 +16,7 @@
 package com.hierynomus.gradle.plugins.jython
 
 import com.hierynomus.gradle.plugins.jython.repository.PypiRepository
+import com.hierynomus.gradle.plugins.jython.repository.PypiLegacyRepository
 import com.hierynomus.gradle.plugins.jython.repository.Repository
 import com.hierynomus.gradle.plugins.jython.repository.UrlRepository
 import org.gradle.api.Project
@@ -38,9 +39,15 @@ class JythonExtension implements Serializable {
         }
     }
 
+    PypiLegacyRepository pypiLegacy(String url) {
+        return new PypiLegacyRepository(url)
+    }
+
     void repository(r) {
         if (r instanceof String && r == "pypi") {
             this.sourceRepositories.add(new PypiRepository())
+        } else if (r instanceof String && r == "pypiLegacy") {
+            this.sourceRepositories.add(new PypiLegacyRepository())
         } else if (r instanceof String) {
             this.sourceRepositories.add(new UrlRepository(r))
         } else if (r instanceof Repository) {

--- a/src/main/groovy/com/hierynomus/gradle/plugins/jython/repository/PypiLegacyRepository.groovy
+++ b/src/main/groovy/com/hierynomus/gradle/plugins/jython/repository/PypiLegacyRepository.groovy
@@ -18,25 +18,23 @@ package com.hierynomus.gradle.plugins.jython.repository
 import com.hierynomus.gradle.plugins.jython.JythonExtension
 import groovy.text.SimpleTemplateEngine
 import groovy.text.Template
-import groovyx.net.http.ContentType
-import groovyx.net.http.HTTPBuilder
-import groovyx.net.http.Method
+import groovy.util.slurpersupport.GPathResult
 import org.gradle.api.artifacts.ExternalModuleDependency
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
 
-class PypiRepository extends Repository {
-    private static final Logger logger = Logging.getLogger(PypiRepository.class)
+class PypiLegacyRepository extends Repository {
+    private static final Logger logger = Logging.getLogger(PypiLegacyRepository.class)
 
     String queryUrl
 
     private Template template
 
-    PypiRepository() {
-        this('https://pypi.org/pypi/${dep.name}/json')
+    PypiLegacyRepository() {
+        this('https://pypi.org/simple/${dep.name}/')
     }
 
-    PypiRepository(String queryUrl) {
+    PypiLegacyRepository(String queryUrl) {
         this.queryUrl = queryUrl
         def engine = new SimpleTemplateEngine()
         this.template = engine.createTemplate(queryUrl)
@@ -46,19 +44,20 @@ class PypiRepository extends Repository {
     String getReleaseUrl(JythonExtension extension, ExternalModuleDependency dep) {
         String queryUrl = template.make(['dep': dep]).toString()
         logger.debug("Querying PyPI: $queryUrl")
-        def queryHttp = newHTTPBuilder(extension, queryUrl)
-        queryHttp.request(Method.GET, ContentType.JSON) {
-            response.success = { resp, json ->
-                if (json.releases) {
-                    def release_urls = json.releases[dep.version]
-                    if (release_urls) {
-                        for (u in release_urls) {
-                            if (u['python_version'] == 'source') {
-                                return u['url']
-                            }
-                        }
-                    }
-                }
+
+        XmlSlurper parser = new XmlSlurper(false, true, true)
+        GPathResult packageList = parser.parse(queryUrl)
+        GPathResult packageLink = packageList.depthFirst().find {
+            it.name() == 'a' && it.text().matches("${dep.name}-${dep.version}.(tar\\.gz|zip)")
+        }
+
+        if (packageLink) {
+            URI href = new URI("${packageLink.@href.text()}")
+
+            if (href.isAbsolute()) {
+                return href.normalize()
+            } else {
+                return new URI("${queryUrl}/${packageLink.@href.text()}").normalize()
             }
         }
     }

--- a/src/main/groovy/com/hierynomus/gradle/plugins/jython/repository/PypiRepository.groovy
+++ b/src/main/groovy/com/hierynomus/gradle/plugins/jython/repository/PypiRepository.groovy
@@ -48,7 +48,7 @@ class PypiRepository extends Repository {
         XmlSlurper parser = new XmlSlurper(false, true, true)
         GPathResult packageList = parser.parse(queryUrl)
         GPathResult packageLink = packageList.depthFirst().find {
-            it.name() == 'a' && it.text().equalsIgnoreCase("${dep.name}-${dep.version}.tar.gz")
+            it.name() == 'a' && it.text().matches("${dep.name}-${dep.version}.(tar\\.gz|zip)")
         }
 
         if (packageLink) {

--- a/src/main/groovy/com/hierynomus/gradle/plugins/jython/repository/Repository.groovy
+++ b/src/main/groovy/com/hierynomus/gradle/plugins/jython/repository/Repository.groovy
@@ -39,9 +39,9 @@ abstract class Repository implements Serializable {
                     response.success = { resp, body ->
                         this.logger.debug "Got response: ${resp.statusLine}"
                         this.logger.debug "Response length: ${resp.getFirstHeader('Content-Length')}"
-                        if (url.endsWith(".zip")) {
+                        if (uri.path.endsWith(".zip")) {
                             cachedArtifact = new File(cachePath, artifactName(dep) + ".zip")
-                        } else if (url.endsWith(".tar.gz")) {
+                        } else if (uri.path.endsWith(".tar.gz")) {
                             cachedArtifact = new File(cachePath, artifactName(dep) + ".tar.gz")
                         } else {
                             throw new IllegalArgumentException("Unknown Python artifact extension: $url for dependency $dep")


### PR DESCRIPTION
tested it on pypi.org 

local nexus as follows
```
jython {
  // Replace all repositories with this one
  sourceRepositories = []
  // Add another repository to the existing ones
  repository new com.hierynomus.gradle.plugins.jython.repository.PypiRepository('http://192.168.99.100:32769/repository/ORG-PYTHON-proxy/simple/${dep.name}/')
}
```