### PR TITLE
Plugin to accept GString input parameter as well.

### DIFF
--- a/src/main/groovy/com/hierynomus/gradle/plugins/jython/dependency/PythonDependency.groovy
+++ b/src/main/groovy/com/hierynomus/gradle/plugins/jython/dependency/PythonDependency.groovy
@@ -34,7 +34,7 @@ class PythonDependency extends AbstractExternalModuleDependency {
 
     static PythonDependency create(depInfo) {
         def pd
-        if (depInfo instanceof String) {
+        if (depInfo instanceof String || depInfo instanceof org.codehaus.groovy.runtime.GStringImpl) {
             def split = depInfo.split(":")
             pd = new PythonDependency(split[0], split[1], split[2], null)
             if (split.length > 3) {


### PR DESCRIPTION
Hi, I am from the Digital.ai Eng team. 

Currently, the plugin doesn't accept Groovy GString input parameter.

For Example,  
jython python(":PyYAML:${pyYamlVersion}") in build.gradle.

So, the code changed to accept Groovy GString input parameter as well.

Hi @hierynomus , Kindly approve the change and release it.